### PR TITLE
PHP 8 Build Fix

### DIFF
--- a/wddx.c
+++ b/wddx.c
@@ -1,6 +1,6 @@
 /*
    +----------------------------------------------------------------------+
-   | PHP Version 7                                                        |
+   | PHP Version 8 - With warnings                                        |
    +----------------------------------------------------------------------+
    | Copyright (c) The PHP Group                                          |
    +----------------------------------------------------------------------+
@@ -13,7 +13,7 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
    | Author: Andrei Zmievski <andrei@php.net>                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
  */
 
 #ifdef HAVE_CONFIG_H
@@ -982,7 +982,7 @@ static void php_wddx_pop_element(void *user_data, const XML_Char *name)
 												zval_add_ref, 0);
 
 								if (incomplete_class) {
-									php_store_class_name(&obj, Z_STRVAL(ent1->data), Z_STRLEN(ent1->data));
+									php_store_class_name(&obj, Z_STRVAL(ent1->data));
 								}
 
 								/* Clean up old array entry */


### PR DESCRIPTION
One line change to resolve the following error.
```
pecl-text-wddx-master/wddx.c:985:10: error: too many arguments to function ‘php_store_class_name’
          php_store_class_name(&obj, Z_STRVAL(ent1->data), Z_STRLEN(ent1->data));

```

Php8.0 module Builds successfully when the Length of data is removed as an argument. 
With the below output:

```
/bin/bash pecl-text-wddx-master/libtool --mode=compile cc -I. -Ipecl-text-wddx-master -Ipecl-text-wddx-master/include -Ipecl-text-wddx-master/main -Ipecl-text-wddx-master -I/usr/include/php/20200930 -I/usr/include/php/20200930/main -I/usr/include/php/20200930/TSRM -I/usr/include/php/20200930/Zend -I/usr/include/php/20200930/ext -I/usr/include/php/20200930/ext/date/lib -I/usr/include/libxml2  -DHAVE_CONFIG_H  -g -O2    -c pecl-text-wddx-master/wddx.c -o wddx.lo 
libtool: compile:  cc -I. -Ipecl-text-wddx-master -Ipecl-text-wddx-master/include -Ipecl-text-wddx-master/main -Ipecl-text-wddx-master -I/usr/include/php/20200930 -I/usr/include/php/20200930/main -I/usr/include/php/20200930/TSRM -I/usr/include/php/20200930/Zend -I/usr/include/php/20200930/ext -I/usr/include/php/20200930/ext/date/lib -I/usr/include/libxml2 -DHAVE_CONFIG_H -g -O2 -c pecl-text-wddx-master/wddx.c  -fPIC -DPIC -o .libs/wddx.o
In file included from /usr/include/php/20200930/Zend/zend.h:32,
                 from /usr/include/php/20200930/main/php.h:32,
                 from pecl-text-wddx-master/wddx.c:23:
pecl-text-wddx-master/wddx.c: In function ‘php_wddx_pop_element’:
/usr/include/php/20200930/Zend/zend_string.h:60:31: warning: passing argument 2 of ‘php_store_class_name’ from incompatible pointer type [-Wincompatible-pointer-types]
 #define ZSTR_VAL(zstr)  (zstr)->val
                         ~~~~~~^~~~~
/usr/include/php/20200930/Zend/zend_types.h:804:27: note: in expansion of macro ‘ZSTR_VAL’
 #define Z_STRVAL(zval)    ZSTR_VAL(Z_STR(zval))
                           ^~~~~~~~
pecl-text-wddx-master/wddx.c:985:37: note: in expansion of macro ‘Z_STRVAL’
          php_store_class_name(&obj, Z_STRVAL(ent1->data));
                                     ^~~~~~~~
In file included from pecl-text-wddx-master/wddx.c:32:
/usr/include/php/20200930/ext/standard/php_incomplete_class.h:54:61: note: expected ‘zend_string *’ {aka ‘struct _zend_string *’} but argument is of type ‘char *’
 PHPAPI void php_store_class_name(zval *object, zend_string *name);
                                                ~~~~~~~~~~~~~^~~~
pecl-text-wddx-master/wddx.c:999:49: warning: passing argument 2 of ‘zend_update_property’ from incompatible pointer type [-Wincompatible-pointer-types]
       zend_update_property(Z_OBJCE(ent2->data), &ent2->data, ent1->varname, strlen(ent1->varname), &ent1->data);
                                                 ^~~~~~~~~~~
In file included from /usr/include/php/20200930/main/php.h:36,
                 from pecl-text-wddx-master/wddx.c:23:
/usr/include/php/20200930/Zend/zend_API.h:387:74: note: expected ‘zend_object *’ {aka ‘struct _zend_object *’} but argument is of type ‘zval *’ {aka ‘struct _zval_struct *’}
 ZEND_API void zend_update_property(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zval *value);
                                                             ~~~~~~~~~~~~~^~~~~~
/bin/bash pecl-text-wddx-master/libtool --mode=link cc -shared -Ipecl-text-wddx-master/include -Ipecl-text-wddx-master/main -Ipecl-text-wddx-master -I/usr/include/php/20200930 -I/usr/include/php/20200930/main -I/usr/include/php/20200930/TSRM -I/usr/include/php/20200930/Zend -I/usr/include/php/20200930/ext -I/usr/include/php/20200930/ext/date/lib -I/usr/include/libxml2  -DHAVE_CONFIG_H  -g -O2    -o wddx.la -export-dynamic -avoid-version -prefer-pic -module -rpath pecl-text-wddx-master/modules  wddx.lo 
libtool: link: cc -shared  -fPIC -DPIC  .libs/wddx.o    -g -O2   -Wl,-soname -Wl,wddx.so -o .libs/wddx.so
libtool: link: ( cd ".libs" && rm -f "wddx.la" && ln -s "../wddx.la" "wddx.la" )
/bin/bash pecl-text-wddx-master/libtool --mode=install cp ./wddx.la pecl-text-wddx-master/modules
libtool: install: cp ./.libs/wddx.so pecl-text-wddx-master/modules/wddx.so
libtool: install: cp ./.libs/wddx.lai pecl-text-wddx-master/modules/wddx.la
libtool: finish: PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/sbin" ldconfig -n pecl-text-wddx-master/modules
----------------------------------------------------------------------
Libraries have been installed in:
   pecl-text-wddx-master/modules

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to '/etc/ld.so.conf'

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------

Build complete.
Don't forget to run 'make test'.
```

Built with PHP Version:
```
PHP 8.0.1 (cli) (built: Jan 12 2021 13:59:46) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.1, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.1, Copyright (c), by Zend Technologies
```
